### PR TITLE
Exchanging libc raw types by std::os raw types

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -21,48 +21,44 @@
 
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/ext/atom/.
 
-use std::mem::transmute;
 use atomutils::*;
- 
+use std::mem::transmute;
 
 pub static LV2_ATOM_URI: &'static [u8] = b"http://lv2plug.in/ns/ext/atom\0";
-pub static LV2_ATOM_PREFIX: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#\0"; 
+pub static LV2_ATOM_PREFIX: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#\0";
 
-pub static LV2_ATOM__ATOM          : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Atom\0";
-pub static LV2_ATOM__ATOMPORT      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#AtomPort\0";
-pub static LV2_ATOM__BLANK         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Blank\0";
-pub static LV2_ATOM__BOOL          : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Bool\0";
-pub static LV2_ATOM__CHUNK         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Chunk\0";
-pub static LV2_ATOM__DOUBLE        : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Double\0";
-pub static LV2_ATOM__EVENT         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Event\0";
-pub static LV2_ATOM__FLOAT         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Float\0";
-pub static LV2_ATOM__INT           : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Int\0";
-pub static LV2_ATOM__LITERAL       : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Literal\0";
-pub static LV2_ATOM__LONG          : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Long\0";
-pub static LV2_ATOM__NUMBER        : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Number\0";
-pub static LV2_ATOM__OBJECT        : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Object\0";
-pub static LV2_ATOM__PATH          : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Path\0";
-pub static LV2_ATOM__PROPERTY      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Property\0";
-pub static LV2_ATOM__RESOURCE      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Resource\0";
-pub static LV2_ATOM__SEQUENCE      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Sequence\0";
-pub static LV2_ATOM__SOUND         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Sound\0";
-pub static LV2_ATOM__STRING        : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#String\0";
-pub static LV2_ATOM__TUPLE         : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Tuple\0";
-pub static LV2_ATOM__URI           : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#URI\0";
-pub static LV2_ATOM__URID          : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#URID\0";
-pub static LV2_ATOM__VECTOR        : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Vector\0";
-pub static LV2_ATOM__ATOMTRANSFER  : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#atomTransfer\0";
-pub static LV2_ATOM__BEATTIME      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#beatTime\0";
-pub static LV2_ATOM__BUFFERTYPE    : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#bufferType\0";
-pub static LV2_ATOM__CHILDTYPE     : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#childType\0";
-pub static LV2_ATOM__EVENTTRANSFER : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#eventTransfer\0";
-pub static LV2_ATOM__FRAMETIME     : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#frameTime\0";
-pub static LV2_ATOM__SUPPORTS      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#supports\0";
-pub static LV2_ATOM__TIMEUNIT      : &'static [u8] = b"http://lv2plug.in/ns/ext/atom#timeUnit\0";
-
-
-
-
+pub static LV2_ATOM__ATOM: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Atom\0";
+pub static LV2_ATOM__ATOMPORT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#AtomPort\0";
+pub static LV2_ATOM__BLANK: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Blank\0";
+pub static LV2_ATOM__BOOL: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Bool\0";
+pub static LV2_ATOM__CHUNK: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Chunk\0";
+pub static LV2_ATOM__DOUBLE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Double\0";
+pub static LV2_ATOM__EVENT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Event\0";
+pub static LV2_ATOM__FLOAT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Float\0";
+pub static LV2_ATOM__INT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Int\0";
+pub static LV2_ATOM__LITERAL: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Literal\0";
+pub static LV2_ATOM__LONG: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Long\0";
+pub static LV2_ATOM__NUMBER: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Number\0";
+pub static LV2_ATOM__OBJECT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Object\0";
+pub static LV2_ATOM__PATH: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Path\0";
+pub static LV2_ATOM__PROPERTY: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Property\0";
+pub static LV2_ATOM__RESOURCE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Resource\0";
+pub static LV2_ATOM__SEQUENCE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Sequence\0";
+pub static LV2_ATOM__SOUND: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Sound\0";
+pub static LV2_ATOM__STRING: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#String\0";
+pub static LV2_ATOM__TUPLE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Tuple\0";
+pub static LV2_ATOM__URI: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#URI\0";
+pub static LV2_ATOM__URID: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#URID\0";
+pub static LV2_ATOM__VECTOR: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#Vector\0";
+pub static LV2_ATOM__ATOMTRANSFER: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#atomTransfer\0";
+pub static LV2_ATOM__BEATTIME: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#beatTime\0";
+pub static LV2_ATOM__BUFFERTYPE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#bufferType\0";
+pub static LV2_ATOM__CHILDTYPE: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#childType\0";
+pub static LV2_ATOM__EVENTTRANSFER: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/atom#eventTransfer\0";
+pub static LV2_ATOM__FRAMETIME: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#frameTime\0";
+pub static LV2_ATOM__SUPPORTS: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#supports\0";
+pub static LV2_ATOM__TIMEUNIT: &'static [u8] = b"http://lv2plug.in/ns/ext/atom#timeUnit\0";
 
 /** The header of an atom:Atom. */
 #[repr(C)]
@@ -79,7 +75,7 @@ pub struct LV2AtomInt {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Integer value. */
-    pub body: i32
+    pub body: i32,
 }
 
 /** An atom:Long.  May be cast to LV2_Atom. */
@@ -88,7 +84,7 @@ pub struct LV2AtomLong {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Integer value. */
-    pub body: i64
+    pub body: i64,
 }
 
 /** An atom:Float.  May be cast to LV2_Atom. */
@@ -97,7 +93,7 @@ pub struct LV2AtomFloat {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Float value. */
-    pub body: f32
+    pub body: f32,
 }
 
 /** An atom:Double.  May be cast to LV2_Atom. */
@@ -106,7 +102,7 @@ pub struct LV2AtomDouble {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Double value. */
-    pub body: f64
+    pub body: f64,
 }
 
 pub type LV2AtomBool = LV2AtomInt;
@@ -117,15 +113,14 @@ pub struct LV2AtomURID {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< URID. */
-    pub body: u32
+    pub body: u32,
 }
 
 /** An atom:String.  May be cast to LV2_Atom. */
 #[repr(C)]
 pub struct LV2AtomString {
     /**< Atom header. */
-    pub atom: LV2Atom
-    /* Contents (a null-terminated UTF-8 string) follow here. */
+    pub atom: LV2Atom, /* Contents (a null-terminated UTF-8 string) follow here. */
 }
 
 /** The body of an atom:Literal. */
@@ -134,8 +129,7 @@ pub struct LV2AtomLiteralBody {
     /**< Datatype URID. */
     pub datatype: u32,
     /**< Language URID. */
-    pub lang: u32
-    /* Contents (a null-terminated UTF-8 string) follow here. */
+    pub lang: u32, /* Contents (a null-terminated UTF-8 string) follow here. */
 }
 
 /** An atom:Literal.  May be cast to LV2_Atom. */
@@ -144,7 +138,7 @@ pub struct LV2AtomLiteral {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< URID. */
-    pub body: LV2AtomLiteralBody
+    pub body: LV2AtomLiteralBody,
 }
 
 /** An atom:Tuple.  May be cast to LV2_Atom. */
@@ -161,8 +155,7 @@ pub struct LV2AtomVectorBody {
     /**< The size of each element in the vector. */
     pub child_size: u32,
     /**< The type of each element in the vector. */
-    pub child_type: u32
-    /* Contents (a series of packed atom bodies) follow here. */
+    pub child_type: u32, /* Contents (a series of packed atom bodies) follow here. */
 }
 
 /** An atom:Vector.  May be cast to LV2_Atom. */
@@ -171,7 +164,7 @@ pub struct LV2AtomVector {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Body. */
-    pub body: LV2AtomVectorBody
+    pub body: LV2AtomVectorBody,
 }
 
 /** The body of an atom:Property (e.g. in an atom:Object). */
@@ -182,8 +175,7 @@ pub struct LV2AtomPropertyBody {
     /**< Context URID (may be, and generally is, 0). */
     pub context: u32,
     /**< Value atom header. */
-    pub value: LV2Atom
-    /* Value atom body follows here. */
+    pub value: LV2Atom, /* Value atom body follows here. */
 }
 
 /** An atom:Property.  May be cast to LV2_Atom. */
@@ -192,7 +184,7 @@ pub struct LV2AtomProperty {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Body. */
-    pub body: LV2AtomPropertyBody
+    pub body: LV2AtomPropertyBody,
 }
 
 /** The body of an atom:Object. May be cast to LV2_Atom. */
@@ -201,8 +193,7 @@ pub struct LV2AtomObjectBody {
     /**< URID, or 0 for blank. */
     pub id: u32,
     /**< Type URID (same as rdf:type, for fast dispatch). */
-    pub otype: u32
-    /* Contents (a series of property bodies) follow here. */
+    pub otype: u32, /* Contents (a series of property bodies) follow here. */
 }
 
 /** An atom:Object.  May be cast to LV2_Atom. */
@@ -211,28 +202,25 @@ pub struct LV2AtomObject {
     /**< Atom header. */
     pub atom: LV2Atom,
     /**< Body. */
-    pub body: LV2AtomObjectBody
+    pub body: LV2AtomObjectBody,
 }
 
-
 impl LV2AtomObject {
- 
-    pub unsafe fn foreach<F>(&mut self, mut closure: F) -> () 
-        where F: FnMut(*mut LV2AtomPropertyBody) -> bool {
-
+    pub unsafe fn foreach<F>(&mut self, mut closure: F) -> ()
+    where
+        F: FnMut(*mut LV2AtomPropertyBody) -> bool,
+    {
         let body = &(self.body);
         let mut it = lv2_atom_object_begin(body);
         while !lv2_atom_object_is_end(body, self.atom.size, it) {
             let res = closure(it);
-            if res { break; }
+            if res {
+                break;
+            }
             it = lv2_atom_object_next(it);
         }
     }
 }
-
-
-
-
 
 /** The header of an atom:Event.  Note this type is NOT an LV2_Atom. */
 #[repr(C)]
@@ -286,12 +274,11 @@ pub struct LV2AtomSequence {
     pub body: LV2AtomSequenceBody,
 }
 
-
 impl LV2AtomSequence {
- 
-    pub unsafe fn foreach<F>(&mut self, mut closure: F) -> () 
-        where F: FnMut(*const LV2AtomEvent) -> () {
-
+    pub unsafe fn foreach<F>(&mut self, mut closure: F) -> ()
+    where
+        F: FnMut(*const LV2AtomEvent) -> (),
+    {
         let body = &(self.body);
         let mut it = lv2_atom_sequence_begin(body);
         while !lv2_atom_sequence_is_end(body, self.atom.size, it) {
@@ -300,8 +287,3 @@ impl LV2AtomSequence {
         }
     }
 }
-
-
-
-
-

--- a/src/core.rs
+++ b/src/core.rs
@@ -25,223 +25,223 @@
 
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/lv2core/.
 
-use std::os::raw::{c_char, c_void};
+use std::os::raw::*;
 
 /**
-   Plugin Instance Handle.
+    Plugin Instance Handle.
 
-   This is a handle for one particular instance of a plugin.  It is valid to
-   compare to NULL (or 0 for C++) but otherwise the host MUST NOT attempt to
-   interpret it.
+    This is a handle for one particular instance of a plugin.  It is valid to
+    compare to NULL (or 0 for C++) but otherwise the host MUST NOT attempt to
+    interpret it.
 */
 pub type LV2Handle = *mut c_void;
 
 /**
-   Feature.
+    Feature.
 
-   Features allow hosts to make additional functionality available to plugins
-   without requiring modification to the LV2 API.  Extensions may define new
-   features and specify the `URI` and `data` to be used if necessary.
-   Some features, such as lv2:isLive, do not require the host to pass data.
+    Features allow hosts to make additional functionality available to plugins
+    without requiring modification to the LV2 API.  Extensions may define new
+    features and specify the `URI` and `data` to be used if necessary.
+    Some features, such as lv2:isLive, do not require the host to pass data.
 */
 #[repr(C)]
 pub struct LV2Feature {
-	/**
-	   A globally unique, case-sensitive identifier (URI) for this feature.
+    /**
+        A globally unique, case-sensitive identifier (URI) for this feature.
 
-	   This MUST be a valid URI string as defined by RFC 3986.
-	*/
-	pub uri: *const c_char,
+        This MUST be a valid URI string as defined by RFC 3986.
+    */
+    pub uri: *const c_char,
 
-	/**
-	   Pointer to arbitrary data.
+    /**
+        Pointer to arbitrary data.
 
-	   The format of this data is defined by the extension which describes the
-	   feature with the given `URI`.
-	*/
-	pub data: *mut c_void,
+        The format of this data is defined by the extension which describes the
+        feature with the given `URI`.
+    */
+    pub data: *mut c_void,
 }
 
 /**
-   Plugin Descriptor.
+    Plugin Descriptor.
 
-   This structure provides the core functions necessary to instantiate and use
-   a plugin.
+    This structure provides the core functions necessary to instantiate and use
+    a plugin.
 */
 #[repr(C)]
 pub struct LV2Descriptor {
-	/**
-	   A globally unique, case-sensitive identifier for this plugin.
+    /**
+        A globally unique, case-sensitive identifier for this plugin.
 
-	   This MUST be a valid URI string as defined by RFC 3986.  All plugins with
-	   the same URI MUST be compatible to some degree, see
-	   http://lv2plug.in/ns/lv2core for details.
-	*/
-	pub uri: *const c_char,
+        This MUST be a valid URI string as defined by RFC 3986.  All plugins with
+        the same URI MUST be compatible to some degree, see
+        http://lv2plug.in/ns/lv2core for details.
+    */
+    pub uri: *const c_char,
 
-	/**
-	   Instantiate the plugin.
+    /**
+        Instantiate the plugin.
 
-	   Note that instance initialisation should generally occur in activate()
-	   rather than here. If a host calls instantiate(), it MUST call cleanup()
-	   at some point in the future.
+        Note that instance initialisation should generally occur in activate()
+        rather than here. If a host calls instantiate(), it MUST call cleanup()
+        at some point in the future.
 
-	   @param descriptor Descriptor of the plugin to instantiate.
+        @param descriptor Descriptor of the plugin to instantiate.
 
-	   @param sample_rate Sample rate, in Hz, for the new plugin instance.
+        @param sample_rate Sample rate, in Hz, for the new plugin instance.
 
-	   @param bundle_path Path to the LV2 bundle which contains this plugin
-	   binary. It MUST include the trailing directory separator (e.g. '/') so
-	   that simply appending a filename will yield the path to that file in the
-	   bundle.
+        @param bundle_path Path to the LV2 bundle which contains this plugin
+        binary. It MUST include the trailing directory separator (e.g. '/') so
+        that simply appending a filename will yield the path to that file in the
+        bundle.
 
-	   @param features A NULL terminated array of LV2_Feature structs which
-	   represent the features the host supports. Plugins may refuse to
-	   instantiate if required features are not found here. However, hosts MUST
-	   NOT use this as a discovery mechanism: instead, use the RDF data to
-	   determine which features are required and do not attempt to instantiate
-	   unsupported plugins at all. This parameter MUST NOT be NULL, i.e. a host
-	   that supports no features MUST pass a single element array containing
-	   NULL.
+        @param features A NULL terminated array of LV2_Feature structs which
+        represent the features the host supports. Plugins may refuse to
+        instantiate if required features are not found here. However, hosts MUST
+        NOT use this as a discovery mechanism: instead, use the RDF data to
+        determine which features are required and do not attempt to instantiate
+        unsupported plugins at all. This parameter MUST NOT be NULL, i.e. a host
+        that supports no features MUST pass a single element array containing
+        NULL.
 
-	   @return A handle for the new plugin instance, or NULL if instantiation
-	   has failed.
-	*/
-	pub instantiate: extern "C" fn(
-		descriptor: *const LV2Descriptor,
-		rate: f64,
-		bundle_path: *const c_char,
-		features: *const (*const LV2Feature),
-	) -> LV2Handle,
-	/**
-	   Connect a port on a plugin instance to a memory location.
+        @return A handle for the new plugin instance, or NULL if instantiation
+        has failed.
+    */
+    pub instantiate: extern "C" fn(
+        descriptor: *const LV2Descriptor,
+        rate: f64,
+        bundle_path: *const c_char,
+        features: *const (*const LV2Feature),
+    ) -> LV2Handle,
+    /**
+        Connect a port on a plugin instance to a memory location.
 
-	   Plugin writers should be aware that the host may elect to use the same
-	   buffer for more than one port and even use the same buffer for both
-	   input and output (see lv2:inPlaceBroken in lv2.ttl).
+        Plugin writers should be aware that the host may elect to use the same
+        buffer for more than one port and even use the same buffer for both
+        input and output (see lv2:inPlaceBroken in lv2.ttl).
 
-	   If the plugin has the feature lv2:hardRTCapable then there are various
-	   things that the plugin MUST NOT do within the connect_port() function;
-	   see lv2core.ttl for details.
+        If the plugin has the feature lv2:hardRTCapable then there are various
+        things that the plugin MUST NOT do within the connect_port() function;
+        see lv2core.ttl for details.
 
-	   connect_port() MUST be called at least once for each port before run()
-	   is called, unless that port is lv2:connectionOptional. The plugin must
-	   pay careful attention to the block size passed to run() since the block
-	   allocated may only just be large enough to contain the data, and is not
-	   guaranteed to remain constant between run() calls.
+        connect_port() MUST be called at least once for each port before run()
+        is called, unless that port is lv2:connectionOptional. The plugin must
+        pay careful attention to the block size passed to run() since the block
+        allocated may only just be large enough to contain the data, and is not
+        guaranteed to remain constant between run() calls.
 
-	   connect_port() may be called more than once for a plugin instance to
-	   allow the host to change the buffers that the plugin is reading or
-	   writing. These calls may be made before or after activate() or
-	   deactivate() calls.
+        connect_port() may be called more than once for a plugin instance to
+        allow the host to change the buffers that the plugin is reading or
+        writing. These calls may be made before or after activate() or
+        deactivate() calls.
 
-	   @param instance Plugin instance containing the port.
+        @param instance Plugin instance containing the port.
 
-	   @param port Index of the port to connect. The host MUST NOT try to
-	   connect a port index that is not defined in the plugin's RDF data. If
-	   it does, the plugin's behaviour is undefined (a crash is likely).
+        @param port Index of the port to connect. The host MUST NOT try to
+        connect a port index that is not defined in the plugin's RDF data. If
+        it does, the plugin's behaviour is undefined (a crash is likely).
 
-	   @param data_location Pointer to data of the type defined by the port
-	   type in the plugin's RDF data (e.g. an array of float for an
-	   lv2:AudioPort). This pointer must be stored by the plugin instance and
-	   used to read/write data when run() is called. Data present at the time
-	   of the connect_port() call MUST NOT be considered meaningful.
-	*/
-	pub connect_port: extern "C" fn(handle: LV2Handle, port: u32, data: *mut c_void),
+        @param data_location Pointer to data of the type defined by the port
+        type in the plugin's RDF data (e.g. an array of float for an
+        lv2:AudioPort). This pointer must be stored by the plugin instance and
+        used to read/write data when run() is called. Data present at the time
+        of the connect_port() call MUST NOT be considered meaningful.
+    */
+    pub connect_port: extern "C" fn(handle: LV2Handle, port: u32, data: *mut c_void),
 
-	/**
-	   Initialise a plugin instance and activate it for use.
+    /**
+        Initialise a plugin instance and activate it for use.
 
-	   This is separated from instantiate() to aid real-time support and so
-	   that hosts can reinitialise a plugin instance by calling deactivate()
-	   and then activate(). In this case the plugin instance MUST reset all
-	   state information dependent on the history of the plugin instance except
-	   for any data locations provided by connect_port(). If there is nothing
-	   for activate() to do then this field may be NULL.
+        This is separated from instantiate() to aid real-time support and so
+        that hosts can reinitialise a plugin instance by calling deactivate()
+        and then activate(). In this case the plugin instance MUST reset all
+        state information dependent on the history of the plugin instance except
+        for any data locations provided by connect_port(). If there is nothing
+        for activate() to do then this field may be NULL.
 
-	   When present, hosts MUST call this function once before run() is called
-	   for the first time. This call SHOULD be made as close to the run() call
-	   as possible and indicates to real-time plugins that they are now live,
-	   however plugins MUST NOT rely on a prompt call to run() after
-	   activate().
+        When present, hosts MUST call this function once before run() is called
+        for the first time. This call SHOULD be made as close to the run() call
+        as possible and indicates to real-time plugins that they are now live,
+        however plugins MUST NOT rely on a prompt call to run() after
+        activate().
 
-	   The host MUST NOT call activate() again until deactivate() has been
-	   called first. If a host calls activate(), it MUST call deactivate() at
-	   some point in the future. Note that connect_port() may be called before
-	   or after activate().
-	*/
-	pub activate: Option<extern "C" fn(instance: LV2Handle)>,
+        The host MUST NOT call activate() again until deactivate() has been
+        called first. If a host calls activate(), it MUST call deactivate() at
+        some point in the future. Note that connect_port() may be called before
+        or after activate().
+    */
+    pub activate: Option<extern "C" fn(instance: LV2Handle)>,
 
-	/**
-	   Run a plugin instance for a block.
+    /**
+        Run a plugin instance for a block.
 
-	   Note that if an activate() function exists then it must be called before
-	   run(). If deactivate() is called for a plugin instance then run() may
-	   not be called until activate() has been called again.
+        Note that if an activate() function exists then it must be called before
+        run(). If deactivate() is called for a plugin instance then run() may
+        not be called until activate() has been called again.
 
-	   If the plugin has the feature lv2:hardRTCapable then there are various
-	   things that the plugin MUST NOT do within the run() function (see
-	   lv2core.ttl for details).
+        If the plugin has the feature lv2:hardRTCapable then there are various
+        things that the plugin MUST NOT do within the run() function (see
+        lv2core.ttl for details).
 
-	   As a special case, when `sample_count` is 0, the plugin should update
-	   any output ports that represent a single instant in time (e.g. control
-	   ports, but not audio ports). This is particularly useful for latent
-	   plugins, which should update their latency output port so hosts can
-	   pre-roll plugins to compute latency. Plugins MUST NOT crash when
-	   `sample_count` is 0.
+        As a special case, when `sample_count` is 0, the plugin should update
+        any output ports that represent a single instant in time (e.g. control
+        ports, but not audio ports). This is particularly useful for latent
+        plugins, which should update their latency output port so hosts can
+        pre-roll plugins to compute latency. Plugins MUST NOT crash when
+        `sample_count` is 0.
 
-	   @param instance Instance to be run.
+        @param instance Instance to be run.
 
-	   @param sample_count The block size (in samples) for which the plugin
-	   instance must run.
-	*/
-	pub run: extern "C" fn(instance: LV2Handle, n_samples: u32),
+        @param sample_count The block size (in samples) for which the plugin
+        instance must run.
+    */
+    pub run: extern "C" fn(instance: LV2Handle, n_samples: u32),
 
-	/**
-	   Deactivate a plugin instance (counterpart to activate()).
+    /**
+        Deactivate a plugin instance (counterpart to activate()).
 
-	   Hosts MUST deactivate all activated instances after they have been run()
-	   for the last time. This call SHOULD be made as close to the last run()
-	   call as possible and indicates to real-time plugins that they are no
-	   longer live, however plugins MUST NOT rely on prompt deactivation. If
-	   there is nothing for deactivate() to do then this field may be NULL
+        Hosts MUST deactivate all activated instances after they have been run()
+        for the last time. This call SHOULD be made as close to the last run()
+        call as possible and indicates to real-time plugins that they are no
+        longer live, however plugins MUST NOT rely on prompt deactivation. If
+        there is nothing for deactivate() to do then this field may be NULL
 
-	   Deactivation is not similar to pausing since the plugin instance will be
-	   reinitialised by activate(). However, deactivate() itself MUST NOT fully
-	   reset plugin state. For example, the host may deactivate a plugin, then
-	   store its state (using some extension to do so).
+        Deactivation is not similar to pausing since the plugin instance will be
+        reinitialised by activate(). However, deactivate() itself MUST NOT fully
+        reset plugin state. For example, the host may deactivate a plugin, then
+        store its state (using some extension to do so).
 
-	   Hosts MUST NOT call deactivate() unless activate() was previously
-	   called. Note that connect_port() may be called before or after
-	   deactivate().
-	*/
-	pub deactivate: Option<extern "C" fn(instance: LV2Handle)>,
+        Hosts MUST NOT call deactivate() unless activate() was previously
+        called. Note that connect_port() may be called before or after
+        deactivate().
+    */
+    pub deactivate: Option<extern "C" fn(instance: LV2Handle)>,
 
-	/**
-	   Clean up a plugin instance (counterpart to instantiate()).
+    /**
+        Clean up a plugin instance (counterpart to instantiate()).
 
-	   Once an instance of a plugin has been finished with it must be deleted
-	   using this function. The instance handle passed ceases to be valid after
-	   this call.
+        Once an instance of a plugin has been finished with it must be deleted
+        using this function. The instance handle passed ceases to be valid after
+        this call.
 
-	   If activate() was called for a plugin instance then a corresponding call
-	   to deactivate() MUST be made before cleanup() is called. Hosts MUST NOT
-	   call cleanup() unless instantiate() was previously called.
-	*/
-	pub cleanup: extern "C" fn(instance: LV2Handle),
+        If activate() was called for a plugin instance then a corresponding call
+        to deactivate() MUST be made before cleanup() is called. Hosts MUST NOT
+        call cleanup() unless instantiate() was previously called.
+    */
+    pub cleanup: extern "C" fn(instance: LV2Handle),
 
-	/**
-	   Return additional plugin data defined by some extenion.
+    /**
+        Return additional plugin data defined by some extenion.
 
-	   A typical use of this facility is to return a struct containing function
-	   pointers to extend the LV2_Descriptor API.
+        A typical use of this facility is to return a struct containing function
+        pointers to extend the LV2_Descriptor API.
 
-	   The actual type and meaning of the returned object MUST be specified
-	   precisely by the extension. This function MUST return NULL for any
-	   unsupported URI. If a plugin does not support any extension data, this
-	   field may be NULL.
+        The actual type and meaning of the returned object MUST be specified
+        precisely by the extension. This function MUST return NULL for any
+        unsupported URI. If a plugin does not support any extension data, this
+        field may be NULL.
 
-	   The host is never responsible for freeing the returned value.
-	*/
-	pub extension_data: extern "C" fn(uri: *const c_char) -> (*const c_void),
+        The host is never responsible for freeing the returned value.
+    */
+    pub extension_data: extern "C" fn(uri: *const c_char) -> (*const c_void),
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -25,7 +25,7 @@
 
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/lv2core/.
 
-use libc;
+use std::os::raw::{c_char, c_void};
 
 /**
    Plugin Instance Handle.
@@ -34,7 +34,7 @@ use libc;
    compare to NULL (or 0 for C++) but otherwise the host MUST NOT attempt to
    interpret it.
 */
-pub type LV2Handle = *mut libc::c_void;
+pub type LV2Handle = *mut c_void;
 
 /**
    Feature.
@@ -46,20 +46,20 @@ pub type LV2Handle = *mut libc::c_void;
 */
 #[repr(C)]
 pub struct LV2Feature {
-    /**
+	/**
 	   A globally unique, case-sensitive identifier (URI) for this feature.
 
 	   This MUST be a valid URI string as defined by RFC 3986.
 	*/
-    pub uri: *const libc::c_char,
+	pub uri: *const c_char,
 
-    /**
+	/**
 	   Pointer to arbitrary data.
 
 	   The format of this data is defined by the extension which describes the
 	   feature with the given `URI`.
 	*/
-    pub data: *mut libc::c_void,
+	pub data: *mut c_void,
 }
 
 /**
@@ -70,16 +70,16 @@ pub struct LV2Feature {
 */
 #[repr(C)]
 pub struct LV2Descriptor {
-    /**
+	/**
 	   A globally unique, case-sensitive identifier for this plugin.
 
 	   This MUST be a valid URI string as defined by RFC 3986.  All plugins with
 	   the same URI MUST be compatible to some degree, see
 	   http://lv2plug.in/ns/lv2core for details.
 	*/
-    pub uri: *const libc::c_char,
+	pub uri: *const c_char,
 
-    /**
+	/**
 	   Instantiate the plugin.
 
 	   Note that instance initialisation should generally occur in activate()
@@ -107,12 +107,13 @@ pub struct LV2Descriptor {
 	   @return A handle for the new plugin instance, or NULL if instantiation
 	   has failed.
 	*/
-    pub instantiate: extern "C" fn(descriptor: *const LV2Descriptor,
-                                       rate: f64,
-                                       bundle_path: *const libc::c_char,
-                                       features: *const (*const LV2Feature))
-                                       -> LV2Handle,
-    /**
+	pub instantiate: extern "C" fn(
+		descriptor: *const LV2Descriptor,
+		rate: f64,
+		bundle_path: *const c_char,
+		features: *const (*const LV2Feature),
+	) -> LV2Handle,
+	/**
 	   Connect a port on a plugin instance to a memory location.
 
 	   Plugin writers should be aware that the host may elect to use the same
@@ -146,9 +147,9 @@ pub struct LV2Descriptor {
 	   used to read/write data when run() is called. Data present at the time
 	   of the connect_port() call MUST NOT be considered meaningful.
 	*/
-    pub connect_port: extern "C" fn(handle: LV2Handle, port: u32, data: *mut libc::c_void),
+	pub connect_port: extern "C" fn(handle: LV2Handle, port: u32, data: *mut c_void),
 
-    /**
+	/**
 	   Initialise a plugin instance and activate it for use.
 
 	   This is separated from instantiate() to aid real-time support and so
@@ -169,9 +170,9 @@ pub struct LV2Descriptor {
 	   some point in the future. Note that connect_port() may be called before
 	   or after activate().
 	*/
-    pub activate: Option<extern "C" fn(instance: LV2Handle)>,
+	pub activate: Option<extern "C" fn(instance: LV2Handle)>,
 
-    /**
+	/**
 	   Run a plugin instance for a block.
 
 	   Note that if an activate() function exists then it must be called before
@@ -194,9 +195,9 @@ pub struct LV2Descriptor {
 	   @param sample_count The block size (in samples) for which the plugin
 	   instance must run.
 	*/
-    pub run: extern "C" fn(instance: LV2Handle, n_samples: u32),
+	pub run: extern "C" fn(instance: LV2Handle, n_samples: u32),
 
-    /**
+	/**
 	   Deactivate a plugin instance (counterpart to activate()).
 
 	   Hosts MUST deactivate all activated instances after they have been run()
@@ -214,9 +215,9 @@ pub struct LV2Descriptor {
 	   called. Note that connect_port() may be called before or after
 	   deactivate().
 	*/
-    pub deactivate: Option<extern "C" fn(instance: LV2Handle)>,
+	pub deactivate: Option<extern "C" fn(instance: LV2Handle)>,
 
-    /**
+	/**
 	   Clean up a plugin instance (counterpart to instantiate()).
 
 	   Once an instance of a plugin has been finished with it must be deleted
@@ -227,9 +228,9 @@ pub struct LV2Descriptor {
 	   to deactivate() MUST be made before cleanup() is called. Hosts MUST NOT
 	   call cleanup() unless instantiate() was previously called.
 	*/
-    pub cleanup: extern "C" fn(instance: LV2Handle),
+	pub cleanup: extern "C" fn(instance: LV2Handle),
 
-    /**
+	/**
 	   Return additional plugin data defined by some extenion.
 
 	   A typical use of this facility is to return a struct containing function
@@ -242,5 +243,5 @@ pub struct LV2Descriptor {
 
 	   The host is never responsible for freeing the returned value.
 	*/
-    pub extension_data: extern "C" fn(uri: *const u8) -> (*const libc::c_void),
+	pub extension_data: extern "C" fn(uri: *const c_char) -> (*const c_void),
 }

--- a/src/coreutils.rs
+++ b/src/coreutils.rs
@@ -20,10 +20,9 @@
 
 //! Documentation of the corresponding C header files (part of LV2 core): http://lv2plug.in/ns/lv2core/.
 
-use std::os::raw::{c_char, c_void};
 use core::*;
 use std::ffi::*;
-
+use std::os::raw::*;
 
 /**
    Return the data for a feature in a features array.
@@ -32,10 +31,10 @@ use std::ffi::*;
    only useful for features with data, and can not detect features that are
    present but have NULL data.
 */
-pub unsafe fn lv2_features_data(features: *const *const LV2Feature,
-                                curi: *const c_char)
-                                -> *mut c_void {
-
+pub unsafe fn lv2_features_data(
+    features: *const *const LV2Feature,
+    curi: *const c_char,
+) -> *mut c_void {
     if !features.is_null() {
         let mut feature = *features;
         let nul = 0 as *const LV2Feature;
@@ -43,7 +42,9 @@ pub unsafe fn lv2_features_data(features: *const *const LV2Feature,
 
         let mut i = 0;
         while feature != nul {
-            let f = CStr::from_ptr((*feature).uri).to_string_lossy().into_owned();
+            let f = CStr::from_ptr((*feature).uri)
+                .to_string_lossy()
+                .into_owned();
             if f == uri {
                 return (*feature).data;
             }
@@ -51,18 +52,15 @@ pub unsafe fn lv2_features_data(features: *const *const LV2Feature,
             feature = *features.offset(i);
             i += 1;
         }
-
     }
     0 as *mut c_void
 }
-
 
 pub struct FeatureHelper {
     urid: *const c_char,
     data: *mut *mut c_void,
     required: bool,
 }
-
 
 /**
    Query a features array.
@@ -86,10 +84,10 @@ pub struct FeatureHelper {
 
    @return NULL on success, otherwise the URI of this missing feature.
 */
-pub unsafe fn lv2_features_query(features: *const *const LV2Feature,
-                                 query: &[FeatureHelper])
-                                 -> *const c_char {
-
+pub unsafe fn lv2_features_query(
+    features: *const *const LV2Feature,
+    query: &[FeatureHelper],
+) -> *const c_char {
     for it in query {
         let mut data = it.data;
         *data = lv2_features_data(features, it.urid);

--- a/src/coreutils.rs
+++ b/src/coreutils.rs
@@ -20,7 +20,7 @@
 
 //! Documentation of the corresponding C header files (part of LV2 core): http://lv2plug.in/ns/lv2core/.
 
-use libc::{c_char, c_void};
+use std::os::raw::{c_char, c_void};
 use core::*;
 use std::ffi::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
 // test
 extern crate libc;
 
-pub mod core;
 pub mod atom;
-pub mod ui;
-pub mod urid;
+pub mod atomutils;
+pub mod core;
+pub mod coreutils;
 pub mod midi;
 pub mod time;
-pub mod coreutils;
-pub mod atomutils;
+pub mod ui;
+pub mod urid;
 
-pub use core::*;
 pub use atom::*;
-pub use ui::*;
-pub use urid::*;
+pub use atomutils::*;
+pub use core::*;
+pub use coreutils::*;
 pub use midi::*;
 pub use time::*;
-pub use coreutils::*;
-pub use atomutils::*;
+pub use ui::*;
+pub use urid::*;

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -19,49 +19,57 @@
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/ext/midi/midi.html.
 
 pub static LV2_MIDI_URI: &'static [u8] = b"http://lv2plug.in/ns/ext/midi\0";
-pub static LV2_MIDI_PREFIX: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#\0"; 
+pub static LV2_MIDI_PREFIX: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#\0";
 
-pub static LV2_MIDI__ACTIVESENSE      : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#ActiveSense\0";
-pub static LV2_MIDI__AFTERTOUCH       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Aftertouch\0";
-pub static LV2_MIDI__BENDER           : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Bender\0";
-pub static LV2_MIDI__CHANNELPRESSURE  : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#ChannelPressure\0";
-pub static LV2_MIDI__CHUNK            : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Chunk\0";
-pub static LV2_MIDI__CLOCK            : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Clock\0";
-pub static LV2_MIDI__CONTINUE         : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Continue\0";
-pub static LV2_MIDI__CONTROLLER       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Controller\0";
-pub static LV2_MIDI__MIDIEVENT        : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#MidiEvent\0";
-pub static LV2_MIDI__NOTEOFF          : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#NoteOff\0";
-pub static LV2_MIDI__NOTEON           : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#NoteOn\0";
-pub static LV2_MIDI__PROGRAMCHANGE    : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#ProgramChange\0";
-pub static LV2_MIDI__QUARTERFRAME     : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#QuarterFrame\0";
-pub static LV2_MIDI__RESET            : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Reset\0";
-pub static LV2_MIDI__SONGPOSITION     : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SongPosition\0";
-pub static LV2_MIDI__SONGSELECT       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SongSelect\0";
-pub static LV2_MIDI__START            : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Start\0";
-pub static LV2_MIDI__STOP             : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Stop\0";
-pub static LV2_MIDI__SYSTEMCOMMON     : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SystemCommon\0";
-pub static LV2_MIDI__SYSTEMEXCLUSIVE  : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SystemExclusive\0";
-pub static LV2_MIDI__SYSTEMMESSAGE    : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SystemMessage\0";
-pub static LV2_MIDI__SYSTEMREALTIME   : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SystemRealtime\0";
-pub static LV2_MIDI__TICK             : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Tick\0";
-pub static LV2_MIDI__TUNEREQUEST      : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#TuneRequest\0";
-pub static LV2_MIDI__VOICEMESSAGE     : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#VoiceMessage\0";
-pub static LV2_MIDI__BENDERVALUE      : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#benderValue\0";
-pub static LV2_MIDI__BINDING          : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#binding\0";
-pub static LV2_MIDI__BYTENUMBER       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#byteNumber\0";
-pub static LV2_MIDI__CHANNEL          : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#channel\0";
-pub static LV2_MIDI___CHUNK           : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#chunk\0";
-pub static LV2_MIDI__CONTROLLERNUMBER : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#controllerNumber\0";
-pub static LV2_MIDI__CONTROLLERVALUE  : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#controllerValue\0";
-pub static LV2_MIDI__NOTENUMBER       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#noteNumber\0";
-pub static LV2_MIDI__PRESSURE         : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#pressure\0";
-pub static LV2_MIDI__PROGRAMNUMBER    : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#programNumber\0";
-pub static LV2_MIDI__PROPERTY         : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#property\0";
-pub static LV2_MIDI__SONGNUMBER       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#songNumber\0";
-pub static LV2_MIDI___SONGPOSITION    : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#songPosition\0";
-pub static LV2_MIDI__STATUS           : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#status\0";
-pub static LV2_MIDI__STATUSMASK       : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#statusMask\0";
-pub static LV2_MIDI__VELOCITY         : &'static [u8] = b"http://lv2plug.in/ns/ext/midi#velocity\0";
+pub static LV2_MIDI__ACTIVESENSE: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#ActiveSense\0";
+pub static LV2_MIDI__AFTERTOUCH: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Aftertouch\0";
+pub static LV2_MIDI__BENDER: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Bender\0";
+pub static LV2_MIDI__CHANNELPRESSURE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#ChannelPressure\0";
+pub static LV2_MIDI__CHUNK: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Chunk\0";
+pub static LV2_MIDI__CLOCK: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Clock\0";
+pub static LV2_MIDI__CONTINUE: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Continue\0";
+pub static LV2_MIDI__CONTROLLER: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Controller\0";
+pub static LV2_MIDI__MIDIEVENT: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#MidiEvent\0";
+pub static LV2_MIDI__NOTEOFF: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#NoteOff\0";
+pub static LV2_MIDI__NOTEON: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#NoteOn\0";
+pub static LV2_MIDI__PROGRAMCHANGE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#ProgramChange\0";
+pub static LV2_MIDI__QUARTERFRAME: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#QuarterFrame\0";
+pub static LV2_MIDI__RESET: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Reset\0";
+pub static LV2_MIDI__SONGPOSITION: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SongPosition\0";
+pub static LV2_MIDI__SONGSELECT: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SongSelect\0";
+pub static LV2_MIDI__START: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Start\0";
+pub static LV2_MIDI__STOP: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Stop\0";
+pub static LV2_MIDI__SYSTEMCOMMON: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#SystemCommon\0";
+pub static LV2_MIDI__SYSTEMEXCLUSIVE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#SystemExclusive\0";
+pub static LV2_MIDI__SYSTEMMESSAGE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#SystemMessage\0";
+pub static LV2_MIDI__SYSTEMREALTIME: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#SystemRealtime\0";
+pub static LV2_MIDI__TICK: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#Tick\0";
+pub static LV2_MIDI__TUNEREQUEST: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#TuneRequest\0";
+pub static LV2_MIDI__VOICEMESSAGE: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#VoiceMessage\0";
+pub static LV2_MIDI__BENDERVALUE: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#benderValue\0";
+pub static LV2_MIDI__BINDING: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#binding\0";
+pub static LV2_MIDI__BYTENUMBER: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#byteNumber\0";
+pub static LV2_MIDI__CHANNEL: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#channel\0";
+pub static LV2_MIDI___CHUNK: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#chunk\0";
+pub static LV2_MIDI__CONTROLLERNUMBER: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#controllerNumber\0";
+pub static LV2_MIDI__CONTROLLERVALUE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#controllerValue\0";
+pub static LV2_MIDI__NOTENUMBER: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#noteNumber\0";
+pub static LV2_MIDI__PRESSURE: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#pressure\0";
+pub static LV2_MIDI__PROGRAMNUMBER: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/midi#programNumber\0";
+pub static LV2_MIDI__PROPERTY: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#property\0";
+pub static LV2_MIDI__SONGNUMBER: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#songNumber\0";
+pub static LV2_MIDI___SONGPOSITION: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#songPosition\0";
+pub static LV2_MIDI__STATUS: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#status\0";
+pub static LV2_MIDI__STATUSMASK: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#statusMask\0";
+pub static LV2_MIDI__VELOCITY: &'static [u8] = b"http://lv2plug.in/ns/ext/midi#velocity\0";
 
 /**
    MIDI Message Type.
@@ -72,177 +80,175 @@ pub static LV2_MIDI__VELOCITY         : &'static [u8] = b"http://lv2plug.in/ns/e
    lv2_midi_get_type() on the status byte.
 */
 pub enum LV2MidiMessageType {
-	LV2MidiMsgInvalid        ,  
-	LV2MidiMsgNoteOff        ,  
-	LV2MidiMsgNoteOn         ,  
-	LV2MidiMsgNotePressure   ,  
-	LV2MidiMsgController     ,  
-	LV2MidiMsgPgmChange      ,  
-	LV2MidiMsgChannelPressure,  
-	LV2MidiMsgBender         ,  
-	LV2MidiMsgSystemExclusive,  
-	LV2MidiMsgMtcQuarter     ,  
-	LV2MidiMsgSongPos        ,  
-	LV2MidiMsgSongSelect     ,  
-	LV2MidiMsgTuneRequest    ,  
-	LV2MidiMsgClock          ,  
-	LV2MidiMsgStart          ,  
-	LV2MidiMsgContinue       ,  
-	LV2MidiMsgStop           ,  
-	LV2MidiMsgActiveSense    ,  
-	LV2MidiMsgReset            
+    LV2MidiMsgInvalid,
+    LV2MidiMsgNoteOff,
+    LV2MidiMsgNoteOn,
+    LV2MidiMsgNotePressure,
+    LV2MidiMsgController,
+    LV2MidiMsgPgmChange,
+    LV2MidiMsgChannelPressure,
+    LV2MidiMsgBender,
+    LV2MidiMsgSystemExclusive,
+    LV2MidiMsgMtcQuarter,
+    LV2MidiMsgSongPos,
+    LV2MidiMsgSongSelect,
+    LV2MidiMsgTuneRequest,
+    LV2MidiMsgClock,
+    LV2MidiMsgStart,
+    LV2MidiMsgContinue,
+    LV2MidiMsgStop,
+    LV2MidiMsgActiveSense,
+    LV2MidiMsgReset,
 }
 
-
 impl LV2MidiMessageType {
-
     pub fn from_u8(x: u8) -> LV2MidiMessageType {
         match x {
-			0    => LV2MidiMessageType::LV2MidiMsgInvalid        ,
-			0x80 => LV2MidiMessageType::LV2MidiMsgNoteOff        ,
-			0x90 => LV2MidiMessageType::LV2MidiMsgNoteOn         ,
-			0xA0 => LV2MidiMessageType::LV2MidiMsgNotePressure   ,
-			0xB0 => LV2MidiMessageType::LV2MidiMsgController     ,
-			0xC0 => LV2MidiMessageType::LV2MidiMsgPgmChange      ,
-			0xD0 => LV2MidiMessageType::LV2MidiMsgChannelPressure,
-			0xE0 => LV2MidiMessageType::LV2MidiMsgBender         ,
-			0xF0 => LV2MidiMessageType::LV2MidiMsgSystemExclusive,
-			0xF1 => LV2MidiMessageType::LV2MidiMsgMtcQuarter     ,
-			0xF2 => LV2MidiMessageType::LV2MidiMsgSongPos        ,
-			0xF3 => LV2MidiMessageType::LV2MidiMsgSongSelect     ,
-			0xF6 => LV2MidiMessageType::LV2MidiMsgTuneRequest    ,
-			0xF8 => LV2MidiMessageType::LV2MidiMsgClock          ,
-			0xFA => LV2MidiMessageType::LV2MidiMsgStart          ,
-			0xFB => LV2MidiMessageType::LV2MidiMsgContinue       ,
-			0xFC => LV2MidiMessageType::LV2MidiMsgStop           ,
-			0xFE => LV2MidiMessageType::LV2MidiMsgActiveSense    ,
-			0xFF => LV2MidiMessageType::LV2MidiMsgReset          ,
-			_ => LV2MidiMessageType::LV2MidiMsgInvalid
+            0 => LV2MidiMessageType::LV2MidiMsgInvalid,
+            0x80 => LV2MidiMessageType::LV2MidiMsgNoteOff,
+            0x90 => LV2MidiMessageType::LV2MidiMsgNoteOn,
+            0xA0 => LV2MidiMessageType::LV2MidiMsgNotePressure,
+            0xB0 => LV2MidiMessageType::LV2MidiMsgController,
+            0xC0 => LV2MidiMessageType::LV2MidiMsgPgmChange,
+            0xD0 => LV2MidiMessageType::LV2MidiMsgChannelPressure,
+            0xE0 => LV2MidiMessageType::LV2MidiMsgBender,
+            0xF0 => LV2MidiMessageType::LV2MidiMsgSystemExclusive,
+            0xF1 => LV2MidiMessageType::LV2MidiMsgMtcQuarter,
+            0xF2 => LV2MidiMessageType::LV2MidiMsgSongPos,
+            0xF3 => LV2MidiMessageType::LV2MidiMsgSongSelect,
+            0xF6 => LV2MidiMessageType::LV2MidiMsgTuneRequest,
+            0xF8 => LV2MidiMessageType::LV2MidiMsgClock,
+            0xFA => LV2MidiMessageType::LV2MidiMsgStart,
+            0xFB => LV2MidiMessageType::LV2MidiMsgContinue,
+            0xFC => LV2MidiMessageType::LV2MidiMsgStop,
+            0xFE => LV2MidiMessageType::LV2MidiMsgActiveSense,
+            0xFF => LV2MidiMessageType::LV2MidiMsgReset,
+            _ => LV2MidiMessageType::LV2MidiMsgInvalid,
         }
     }
 
     pub fn to_u8(self) -> u8 {
         match self {
-			LV2MidiMessageType::LV2MidiMsgInvalid         => 0,   
-			LV2MidiMessageType::LV2MidiMsgNoteOff         => 0x80,
-			LV2MidiMessageType::LV2MidiMsgNoteOn          => 0x90,
-			LV2MidiMessageType::LV2MidiMsgNotePressure    => 0xA0,
-			LV2MidiMessageType::LV2MidiMsgController      => 0xB0,
-			LV2MidiMessageType::LV2MidiMsgPgmChange       => 0xC0,
-			LV2MidiMessageType::LV2MidiMsgChannelPressure => 0xD0,
-			LV2MidiMessageType::LV2MidiMsgBender          => 0xE0,
-			LV2MidiMessageType::LV2MidiMsgSystemExclusive => 0xF0,
-			LV2MidiMessageType::LV2MidiMsgMtcQuarter      => 0xF1,
-			LV2MidiMessageType::LV2MidiMsgSongPos         => 0xF2,
-			LV2MidiMessageType::LV2MidiMsgSongSelect      => 0xF3,
-			LV2MidiMessageType::LV2MidiMsgTuneRequest     => 0xF6,
-			LV2MidiMessageType::LV2MidiMsgClock           => 0xF8,
-			LV2MidiMessageType::LV2MidiMsgStart           => 0xFA,
-			LV2MidiMessageType::LV2MidiMsgContinue        => 0xFB,
-			LV2MidiMessageType::LV2MidiMsgStop            => 0xFC,
-			LV2MidiMessageType::LV2MidiMsgActiveSense     => 0xFE,
-			LV2MidiMessageType::LV2MidiMsgReset           => 0xFF 
-		}
+            LV2MidiMessageType::LV2MidiMsgInvalid => 0,
+            LV2MidiMessageType::LV2MidiMsgNoteOff => 0x80,
+            LV2MidiMessageType::LV2MidiMsgNoteOn => 0x90,
+            LV2MidiMessageType::LV2MidiMsgNotePressure => 0xA0,
+            LV2MidiMessageType::LV2MidiMsgController => 0xB0,
+            LV2MidiMessageType::LV2MidiMsgPgmChange => 0xC0,
+            LV2MidiMessageType::LV2MidiMsgChannelPressure => 0xD0,
+            LV2MidiMessageType::LV2MidiMsgBender => 0xE0,
+            LV2MidiMessageType::LV2MidiMsgSystemExclusive => 0xF0,
+            LV2MidiMessageType::LV2MidiMsgMtcQuarter => 0xF1,
+            LV2MidiMessageType::LV2MidiMsgSongPos => 0xF2,
+            LV2MidiMessageType::LV2MidiMsgSongSelect => 0xF3,
+            LV2MidiMessageType::LV2MidiMsgTuneRequest => 0xF6,
+            LV2MidiMessageType::LV2MidiMsgClock => 0xF8,
+            LV2MidiMessageType::LV2MidiMsgStart => 0xFA,
+            LV2MidiMessageType::LV2MidiMsgContinue => 0xFB,
+            LV2MidiMessageType::LV2MidiMsgStop => 0xFC,
+            LV2MidiMessageType::LV2MidiMsgActiveSense => 0xFE,
+            LV2MidiMessageType::LV2MidiMsgReset => 0xFF,
+        }
     }
 }
 
 /**
    Standard MIDI Controller Numbers.
-*/	
+*/
 pub enum LV2MidiController {
-	LV2MidiCtlMsbBank             = 0x00,  
-	LV2MidiCtlMsbModwheel         = 0x01,  
-	LV2MidiCtlMsbBreath           = 0x02,  
-	LV2MidiCtlMsbFoot             = 0x04,  
-	LV2MidiCtlMsbPortamentoTime   = 0x05,  
-	LV2MidiCtlMsbDataEntry        = 0x06,  
-	LV2MidiCtlMsbMainVolume       = 0x07,  
-	LV2MidiCtlMsbBalance          = 0x08,  
-	LV2MidiCtlMsbPan              = 0x0A,  
-	LV2MidiCtlMsbExpression       = 0x0B,  
-	LV2MidiCtlMsbEffect1          = 0x0C,  
-	LV2MidiCtlMsbEffect2          = 0x0D,  
-	LV2MidiCtlMsbGeneralPurpose1  = 0x10,  
-	LV2MidiCtlMsbGeneralPurpose2  = 0x11,  
-	LV2MidiCtlMsbGeneralPurpose3  = 0x12,  
-	LV2MidiCtlMsbGeneralPurpose4  = 0x13,  
-	LV2MidiCtlLsbBank             = 0x20,  
-	LV2MidiCtlLsbModwheel         = 0x21,  
-	LV2MidiCtlLsbBreath           = 0x22,  
-	LV2MidiCtlLsbFoot             = 0x24,  
-	LV2MidiCtlLsbPortamentoTime   = 0x25,  
-	LV2MidiCtlLsbDataEtry         = 0x26,  
-	LV2MidiCtlLsbMainVolume       = 0x27,  
-	LV2MidiCtlLsbBalance          = 0x28,  
-	LV2MidiCtlLsbPan              = 0x2A,  
-	LV2MidiCtlLsbExpression       = 0x2B,  
-	LV2MidiCtlLsbEffect1          = 0x2C,  
-	LV2MidiCtlLsbEffect2          = 0x2D,  
-	LV2MidiCtlLsbGeneralPurpose1  = 0x30,  
-	LV2MidiCtlLsbGeneralPurpose2  = 0x31,  
-	LV2MidiCtlLsbGeneralPurpose3  = 0x32,  
-	LV2MidiCtlLsbGeneralPurpose4  = 0x33,  
-	LV2MidiCtlSustain             = 0x40,  
-	LV2MidiCtlPortamento          = 0x41,  
-	LV2MidiCtlSostenuto           = 0x42,  
-	LV2MidiCtlSoftPedal           = 0x43,  
-	LV2MidiCtlLegatoFootswitch    = 0x44,  
-	LV2MidiCtlHold2               = 0x45,  
-	LV2MidiCtlSc1SoundVariation   = 0x46,  
-	LV2MidiCtlSc2Timbre           = 0x47,  
-	LV2MidiCtlSc3ReleaseTime      = 0x48,  
-	LV2MidiCtlSc4AttackTime       = 0x49,  
-	LV2MidiCtlSc5Brightness       = 0x4A,  
-	LV2MidiCtlSc6                 = 0x4B,  
-	LV2MidiCtlSc7                 = 0x4C,  
-	LV2MidiCtlSc8                 = 0x4D,  
-	LV2MidiCtlSc9                 = 0x4E,  
-	LV2MidiCtlSc10                = 0x4F,  
-	LV2MidiCtlGeneralPurpose5     = 0x50,  
-	LV2MidiCtlGeneralPurpose6     = 0x51,  
-	LV2MidiCtlGeneralPurpose7     = 0x52,  
-	LV2MidiCtlGeneralPurpose8     = 0x53,  
-	LV2MidiCtlPortamentoControl   = 0x54,  
-	LV2MidiCtlE1ReverbDepth       = 0x5B,  
-	LV2MidiCtlE2TremoloDepth      = 0x5C,  
-	LV2MidiCtlE3ChorusDepth       = 0x5D,  
-	LV2MidiCtlE4DetuneDepth       = 0x5E,  
-	LV2MidiCtlE5PhaserDepth       = 0x5F,  
-	LV2MidiCtlDataIncrement       = 0x60,  
-	LV2MidiCtlDataDecrement       = 0x61,  
-	LV2MidiCtlNrpnLsb             = 0x62,  
-	LV2MidiCtlNrpnMsb             = 0x63,  
-	LV2MidiCtlRpnLsb              = 0x64,  
-	LV2MidiCtlRpnMsb              = 0x65,  
-	LV2MidiCtlAllSoundsOff        = 0x78,  
-	LV2MidiCtlResetControllers    = 0x79,  
-	LV2MidiCtlLocalControlSwitch  = 0x7A,  
-	LV2MidiCtlAllNotesOff         = 0x7B,  
-	LV2MidiCtlOmniOff             = 0x7C,  
-	LV2MidiCtlOmniOn              = 0x7D,  
-	LV2MidiCtlMono1               = 0x7E,  
-	LV2MidiCtlMono2               = 0x7F   
+    LV2MidiCtlMsbBank = 0x00,
+    LV2MidiCtlMsbModwheel = 0x01,
+    LV2MidiCtlMsbBreath = 0x02,
+    LV2MidiCtlMsbFoot = 0x04,
+    LV2MidiCtlMsbPortamentoTime = 0x05,
+    LV2MidiCtlMsbDataEntry = 0x06,
+    LV2MidiCtlMsbMainVolume = 0x07,
+    LV2MidiCtlMsbBalance = 0x08,
+    LV2MidiCtlMsbPan = 0x0A,
+    LV2MidiCtlMsbExpression = 0x0B,
+    LV2MidiCtlMsbEffect1 = 0x0C,
+    LV2MidiCtlMsbEffect2 = 0x0D,
+    LV2MidiCtlMsbGeneralPurpose1 = 0x10,
+    LV2MidiCtlMsbGeneralPurpose2 = 0x11,
+    LV2MidiCtlMsbGeneralPurpose3 = 0x12,
+    LV2MidiCtlMsbGeneralPurpose4 = 0x13,
+    LV2MidiCtlLsbBank = 0x20,
+    LV2MidiCtlLsbModwheel = 0x21,
+    LV2MidiCtlLsbBreath = 0x22,
+    LV2MidiCtlLsbFoot = 0x24,
+    LV2MidiCtlLsbPortamentoTime = 0x25,
+    LV2MidiCtlLsbDataEtry = 0x26,
+    LV2MidiCtlLsbMainVolume = 0x27,
+    LV2MidiCtlLsbBalance = 0x28,
+    LV2MidiCtlLsbPan = 0x2A,
+    LV2MidiCtlLsbExpression = 0x2B,
+    LV2MidiCtlLsbEffect1 = 0x2C,
+    LV2MidiCtlLsbEffect2 = 0x2D,
+    LV2MidiCtlLsbGeneralPurpose1 = 0x30,
+    LV2MidiCtlLsbGeneralPurpose2 = 0x31,
+    LV2MidiCtlLsbGeneralPurpose3 = 0x32,
+    LV2MidiCtlLsbGeneralPurpose4 = 0x33,
+    LV2MidiCtlSustain = 0x40,
+    LV2MidiCtlPortamento = 0x41,
+    LV2MidiCtlSostenuto = 0x42,
+    LV2MidiCtlSoftPedal = 0x43,
+    LV2MidiCtlLegatoFootswitch = 0x44,
+    LV2MidiCtlHold2 = 0x45,
+    LV2MidiCtlSc1SoundVariation = 0x46,
+    LV2MidiCtlSc2Timbre = 0x47,
+    LV2MidiCtlSc3ReleaseTime = 0x48,
+    LV2MidiCtlSc4AttackTime = 0x49,
+    LV2MidiCtlSc5Brightness = 0x4A,
+    LV2MidiCtlSc6 = 0x4B,
+    LV2MidiCtlSc7 = 0x4C,
+    LV2MidiCtlSc8 = 0x4D,
+    LV2MidiCtlSc9 = 0x4E,
+    LV2MidiCtlSc10 = 0x4F,
+    LV2MidiCtlGeneralPurpose5 = 0x50,
+    LV2MidiCtlGeneralPurpose6 = 0x51,
+    LV2MidiCtlGeneralPurpose7 = 0x52,
+    LV2MidiCtlGeneralPurpose8 = 0x53,
+    LV2MidiCtlPortamentoControl = 0x54,
+    LV2MidiCtlE1ReverbDepth = 0x5B,
+    LV2MidiCtlE2TremoloDepth = 0x5C,
+    LV2MidiCtlE3ChorusDepth = 0x5D,
+    LV2MidiCtlE4DetuneDepth = 0x5E,
+    LV2MidiCtlE5PhaserDepth = 0x5F,
+    LV2MidiCtlDataIncrement = 0x60,
+    LV2MidiCtlDataDecrement = 0x61,
+    LV2MidiCtlNrpnLsb = 0x62,
+    LV2MidiCtlNrpnMsb = 0x63,
+    LV2MidiCtlRpnLsb = 0x64,
+    LV2MidiCtlRpnMsb = 0x65,
+    LV2MidiCtlAllSoundsOff = 0x78,
+    LV2MidiCtlResetControllers = 0x79,
+    LV2MidiCtlLocalControlSwitch = 0x7A,
+    LV2MidiCtlAllNotesOff = 0x7B,
+    LV2MidiCtlOmniOff = 0x7C,
+    LV2MidiCtlOmniOn = 0x7D,
+    LV2MidiCtlMono1 = 0x7E,
+    LV2MidiCtlMono2 = 0x7F,
 }
 
 /**
    Return true iff `msg` is a MIDI voice message (which has a channel).
 */
 pub fn lv2_midi_is_voice_message(msg: &[u8]) -> bool {
-	msg[0] >= 0x80 && msg[0] < 0xF0
+    msg[0] >= 0x80 && msg[0] < 0xF0
 }
 
 /**
    Return true iff `msg` is a MIDI system message (which has no channel).
 */
 pub fn lv2_midi_is_system_message(msg: &[u8]) -> bool {
-	match msg[0] {
-		0xF4 => false,
-		0xF5 => false,
-		0xF7 => false,
-		0xF9 => false,
-		0xFD => false,
-		_ => true
-	}
+    match msg[0] {
+        0xF4 => false,
+        0xF5 => false,
+        0xF7 => false,
+        0xF9 => false,
+        0xFD => false,
+        _ => true,
+    }
 }
 
 /**
@@ -250,11 +256,11 @@ pub fn lv2_midi_is_system_message(msg: &[u8]) -> bool {
    @param msg Pointer to the start (status byte) of a MIDI message.
 */
 pub fn lv2_midi_message_type(msg: &[u8]) -> LV2MidiMessageType {
-	if lv2_midi_is_voice_message(msg) {
-		LV2MidiMessageType::from_u8(msg[0] & 0xF0)
-	} else if lv2_midi_is_system_message(msg) {
-		LV2MidiMessageType::from_u8(msg[0])
-	} else {
-		LV2MidiMessageType::LV2MidiMsgInvalid
-	}
+    if lv2_midi_is_voice_message(msg) {
+        LV2MidiMessageType::from_u8(msg[0] & 0xF0)
+    } else if lv2_midi_is_system_message(msg) {
+        LV2MidiMessageType::from_u8(msg[0])
+    } else {
+        LV2MidiMessageType::LV2MidiMsgInvalid
+    }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -20,7 +20,6 @@
 
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/ext/time/time.html.
 
-
 /**
    Properties for describing time, see <http://lv2plug.in/ns/ext/time> for
    details.
@@ -29,19 +28,21 @@
    convenience.
 */
 
-pub static LV2_TIME_URI : &'static [u8] =  b"http://lv2plug.in/ns/ext/time\0";
-pub static LV2_TIME_PREFIX : &'static [u8] = b"http://lv2plug.in/ns/ext/time#\0";
+pub static LV2_TIME_URI: &'static [u8] = b"http://lv2plug.in/ns/ext/time\0";
+pub static LV2_TIME_PREFIX: &'static [u8] = b"http://lv2plug.in/ns/ext/time#\0";
 
-pub static LV2_TIME__TIME            : &'static [u8] = b"http://lv2plug.in/ns/ext/time#Time\0";
-pub static LV2_TIME__POSITION        : &'static [u8] = b"http://lv2plug.in/ns/ext/time#Position\0";
-pub static LV2_TIME__RATE            : &'static [u8] = b"http://lv2plug.in/ns/ext/time#Rate\0";
-pub static LV2_TIME___POSITION        : &'static [u8] = b"http://lv2plug.in/ns/ext/time#position\0";
-pub static LV2_TIME__BARBEAT         : &'static [u8] = b"http://lv2plug.in/ns/ext/time#barBeat\0";
-pub static LV2_TIME__BAR             : &'static [u8] = b"http://lv2plug.in/ns/ext/time#bar\0";
-pub static LV2_TIME__BEAT            : &'static [u8] = b"http://lv2plug.in/ns/ext/time#beat\0";
-pub static LV2_TIME__BEATUNIT        : &'static [u8] = b"http://lv2plug.in/ns/ext/time#beatUnit\0";
-pub static LV2_TIME__BEATSPERBAR     : &'static [u8] = b"http://lv2plug.in/ns/ext/time#beatsPerBar\0";
-pub static LV2_TIME__BEATSPERMINUTE  : &'static [u8] = b"http://lv2plug.in/ns/ext/time#beatsPerMinute\0";
-pub static LV2_TIME__FRAME           : &'static [u8] = b"http://lv2plug.in/ns/ext/time#frame\0";
-pub static LV2_TIME__FRAMESPERSECOND : &'static [u8] = b"http://lv2plug.in/ns/ext/time#framesPerSecond\0";
-pub static LV2_TIME__SPEED           : &'static [u8] = b"http://lv2plug.in/ns/ext/time#speed\0";
+pub static LV2_TIME__TIME: &'static [u8] = b"http://lv2plug.in/ns/ext/time#Time\0";
+pub static LV2_TIME__POSITION: &'static [u8] = b"http://lv2plug.in/ns/ext/time#Position\0";
+pub static LV2_TIME__RATE: &'static [u8] = b"http://lv2plug.in/ns/ext/time#Rate\0";
+pub static LV2_TIME___POSITION: &'static [u8] = b"http://lv2plug.in/ns/ext/time#position\0";
+pub static LV2_TIME__BARBEAT: &'static [u8] = b"http://lv2plug.in/ns/ext/time#barBeat\0";
+pub static LV2_TIME__BAR: &'static [u8] = b"http://lv2plug.in/ns/ext/time#bar\0";
+pub static LV2_TIME__BEAT: &'static [u8] = b"http://lv2plug.in/ns/ext/time#beat\0";
+pub static LV2_TIME__BEATUNIT: &'static [u8] = b"http://lv2plug.in/ns/ext/time#beatUnit\0";
+pub static LV2_TIME__BEATSPERBAR: &'static [u8] = b"http://lv2plug.in/ns/ext/time#beatsPerBar\0";
+pub static LV2_TIME__BEATSPERMINUTE: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/time#beatsPerMinute\0";
+pub static LV2_TIME__FRAME: &'static [u8] = b"http://lv2plug.in/ns/ext/time#frame\0";
+pub static LV2_TIME__FRAMESPERSECOND: &'static [u8] =
+    b"http://lv2plug.in/ns/ext/time#framesPerSecond\0";
+pub static LV2_TIME__SPEED: &'static [u8] = b"http://lv2plug.in/ns/ext/time#speed\0";

--- a/src/urid.rs
+++ b/src/urid.rs
@@ -20,10 +20,10 @@
 
 //! Documentation of the corresponding C header files: http://lv2plug.in/ns/ext/urid/urid.html.
 
-use libc;
+use std::os::raw::*;
 
 pub type LV2Urid = u32;
-pub type LV2UridMapHandle = *mut libc::c_void;
+pub type LV2UridMapHandle = *mut c_void;
 
 pub static LV2_URID_URI: &'static str = "http://lv2plug.in/ns/ext/urid";
 pub static LV2_URID_PREFIX: &'static str = "http://lv2plug.in/ns/ext/urid#";
@@ -31,40 +31,39 @@ pub static LV2_URID_PREFIX: &'static str = "http://lv2plug.in/ns/ext/urid#";
 pub static LV2_URID__MAP: &'static str = "http://lv2plug.in/ns/ext/urid#map";
 pub static LV2_URID__UNMAP: &'static str = "http://lv2plug.in/ns/ext/urid#unmap";
 
-
 /**
    URID Map Feature (LV2_URID__map)
 */
 #[repr(C)]
 pub struct LV2UridMap {
     /**
-	   Opaque pointer to host data.
+       Opaque pointer to host data.
 
-	   This MUST be passed to map_uri() whenever it is called.
-	   Otherwise, it must not be interpreted in any way.
-	*/
+       This MUST be passed to map_uri() whenever it is called.
+       Otherwise, it must not be interpreted in any way.
+    */
     pub handle: LV2UridMapHandle,
 
     /**
-	   Get the numeric ID of a URI.
+       Get the numeric ID of a URI.
 
-	   If the ID does not already exist, it will be created.
+       If the ID does not already exist, it will be created.
 
-	   This function is referentially transparent; any number of calls with the
-	   same arguments is guaranteed to return the same value over the life of a
-	   plugin instance.  Note, however, that several URIs MAY resolve to the
-	   same ID if the host considers those URIs equivalent.
+       This function is referentially transparent; any number of calls with the
+       same arguments is guaranteed to return the same value over the life of a
+       plugin instance.  Note, however, that several URIs MAY resolve to the
+       same ID if the host considers those URIs equivalent.
 
-	   This function is not necessarily very fast or RT-safe: plugins SHOULD
-	   cache any IDs they might need in performance critical situations.
+       This function is not necessarily very fast or RT-safe: plugins SHOULD
+       cache any IDs they might need in performance critical situations.
 
-	   The return value 0 is reserved and indicates that an ID for that URI
-	   could not be created for whatever reason.  However, hosts SHOULD NOT
-	   return 0 from this function in non-exceptional circumstances (i.e. the
-	   URI map SHOULD be dynamic).
+       The return value 0 is reserved and indicates that an ID for that URI
+       could not be created for whatever reason.  However, hosts SHOULD NOT
+       return 0 from this function in non-exceptional circumstances (i.e. the
+       URI map SHOULD be dynamic).
 
-	   @param handle Must be the callback_data member of this struct.
-	   @param uri The URI to be mapped to an integer ID.
-	*/
-    pub map: extern "C" fn(handle: LV2UridMapHandle, uri: *const libc::c_char) -> LV2Urid,
+       @param handle Must be the callback_data member of this struct.
+       @param uri The URI to be mapped to an integer ID.
+    */
+    pub map: extern "C" fn(handle: LV2UridMapHandle, uri: *const c_char) -> LV2Urid,
 }


### PR DESCRIPTION
I was recently messing with this binding and had some trouble using Rust's CStr and CString structs with this binding: Currently, this crate uses the c_char and c_void definitions from the libc crate, but CStr uses the c_char definition from the standard library, for example in [as_ptr](https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr), which is incompatible with libc's definition. You could use additional casts, but I don't think that this is a good solution.

Therefore, I've exchanged every use of the libc types with those from the standard library. I also ran `cargo fmt` by accident, but I don't think that's such a bad thing.