### PR TITLE
Avoid subtraction overflow.

### DIFF
--- a/src/atomutils.rs
+++ b/src/atomutils.rs
@@ -108,7 +108,7 @@ pub unsafe fn lv2_atom_sequence_append_event(
 ) -> *const LV2AtomEvent {
     let total_size = size_of::<LV2AtomEvent>() as u32 + (*event).body.size;
 
-    if (capacity - (*seq).atom.size) < total_size {
+    if capacity < (*seq).atom.size + total_size {
         return 0 as *const LV2AtomEvent;
     }
 


### PR DESCRIPTION
In my test, I created an `LV2AtomSequence` with capacity `1` and the test failed with

```
thread 'event::tests::test_sequence_push_events_fails_after_reaching_capacity' panicked at 'attempt to subtract with overflow', /home/wmedrano/.cargo/registry/src/github.com-1ecc6299db9ec823/lv2_raw-0.2.0/src/atomutils.rs:112:8
```

I think this is an easy fix that preserves the same semantics.